### PR TITLE
Migrate to Zig 0.15.1

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,7 +4,7 @@
     .version = "0.0.1",
 
     .fingerprint = 0xe94cf4c1ed12b57f, // Changing this has security and trust implications.
-    .minimum_zig_version = "0.14.0",
+    .minimum_zig_version = "0.15.1",
 
     .dependencies = .{
         .pcre2 = .{

--- a/src/regex.zig
+++ b/src/regex.zig
@@ -443,11 +443,11 @@ pub const Regex = struct {
     }
 };
 
-fn regex_alloc(size: usize, _: ?*anyopaque) callconv(.C) ?*anyopaque {
+fn regex_alloc(size: usize, _: ?*anyopaque) callconv(.c) ?*anyopaque {
     return std.c.malloc(size);
 }
 
-fn regex_free(ptr: ?*anyopaque, _: ?*anyopaque) callconv(.C) void {
+fn regex_free(ptr: ?*anyopaque, _: ?*anyopaque) callconv(.c) void {
     if (ptr == null) return;
     std.c.free(ptr);
 }
@@ -461,7 +461,7 @@ const re = @cImport({
 });
 
 const Allocator = std.mem.Allocator;
-const AList = std.ArrayList;
+const AList = std.array_list.Managed;
 const SMap = std.StringHashMap;
 const SAMap = std.StringArrayHashMap;
 


### PR DESCRIPTION
Zig 0.15.1 [introduced](https://ziglang.org/download/0.15.1/release-notes.html) some breaking changes.
This PR updates PRCEz to support Zig 0.15.1.